### PR TITLE
Resolved Platform Generation Issue SOLMP-13

### DIFF
--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/R.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/R.cs
@@ -15,6 +15,8 @@
             public const string PlatformOptionsFieldName = "PlatformOptions";
             public const string RenderingPipelineFieldName = "RenderPipeline";
             public const string UnityEditorVersionFieldName = "UnityEditorVersion";
+            public const string IfRequireEditorScriptsFieldName = "IfRequireEditorScripts";
+            public const string IfScoreFieldName = "IfScore";
 
 			public const string ButtonsContainer = "StateButtons";
             public const string GenerateButtonName = "GeneratePackage";

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/File Writers/ManifestWriter.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/File Writers/ManifestWriter.cs
@@ -70,6 +70,10 @@ namespace MiniProject.Core.Editor.PackageWizard
                         throw new ArgumentOutOfRangeException();
                 }
             }
+            //Ensure we don't double include specific directories
+            supportedPlatformNames = supportedPlatformNames
+                .Distinct()
+                .ToArray();
             //Setup friendly version names
             //----------------------------------------------------------//
             

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/PackageGenerator.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/PackageGenerator.cs
@@ -7,6 +7,10 @@ using MiniProject.Core.Editor.Utilities;
 using Scripts.Core;
 using Unity.EditorCoroutines.Editor;
 using UnityEditor;
+using UnityEditor.PackageManager.UI;
+using UnityEditor.VersionControl;
+using UnityEditorInternal;
+using UnityEngine;
 using PackageInfo = UnityEditor.PackageManager.PackageInfo;
 
 namespace MiniProject.Core.Editor.PackageWizard
@@ -31,7 +35,7 @@ namespace MiniProject.Core.Editor.PackageWizard
                 return;
             }
 
-            EditorCoroutineUtility.StartCoroutine(CreateNewPackage(), this);
+            EditorCoroutineUtility.StartCoroutine(CreateNewPackageCoroutine(), this);
         }
 
         private bool IsEmptyName(string packageDataName)
@@ -74,7 +78,7 @@ namespace MiniProject.Core.Editor.PackageWizard
             return true;
         }
 
-        private IEnumerator CreateNewPackage()
+        private IEnumerator CreateNewPackageCoroutine()
         {
             var wait = new EditorWaitForSeconds(.1f);
             yield return wait;
@@ -88,7 +92,10 @@ namespace MiniProject.Core.Editor.PackageWizard
             yield return wait;
             PostGenerate();
             yield return wait;
-            EditorUtility.DisplayDialog(R.UI.Title, "Package created", "Ok");
+
+            yield return new WaitUntil(() => EditorUtility.DisplayDialog(R.UI.Title, "Package created", "Ok"));
+            //FIXME This is not refresh as expected, requires manual refresh by user
+            AssetDatabase.Refresh();
         }
 
         private void TryCreateFiles()

--- a/Packages/com.miniproject.core/Runtime/Scripts/Core/PackageData.cs
+++ b/Packages/com.miniproject.core/Runtime/Scripts/Core/PackageData.cs
@@ -76,6 +76,7 @@ namespace Scripts.Core
         public string Name { get; set; }
 
         public bool HasEditorFolder { get; set; }
+        public bool KeepsScore { get; set; }
         public bool HasSamples { get; set; }
         public string Version { get; set; }
         public string Description { get; set; }


### PR DESCRIPTION
**Jira Link**

[Link to Jira ticket](https://jira.unity3d.com/browse/SOLMP-13)

**Description**

This resolves issues with not being able to generate packages for platforms other than Android & iOS. This was caused by not retrieving the options selected in the UI window to use when building the Package Data information.

**Tech Notes**

- [MOD] Added missing properties to PackageWizard.cs to allow gathering relevant values
- [FIX] Added retrieval of _usesEditorToggle.value for PackageData.HasEditorFolder
- [FIX] Added retrieval of _usesScoreToggle.value for PackageData.KeepsScore
- [FIX] Added missing field names to R.cs for uses Editor Scripts & Keeps Score
- [FIX] Fixed not gathering the selected tags to use in PackageData.ExperienceTags
- [FIX] Fixed not gathering the selected platforms to use in PackageData.Platforms
- [FIX] Fixed potential issue win ManifestWriter.cs that would have included packages twice
- [FIX] Set the AuthorInfo Name to use MiniProject & URL to the GitHub Link
- [MOD] Renamed CreateNewPackage() to CreateNewPackageCoroutine()
- [MOD] Added WaitUntil for dialog window, to allow AssetDatabase.Refresh() to happen after
- [FIX] Added missing KeepsScore bool to PackagesData.cs

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Develop has been merged into this branch
- [x] Project builds and runs in Unity Editor