### PR TITLE
Package Dependencies Improvements

### DIFF
--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyData.uxml
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyData.uxml
@@ -1,0 +1,13 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="True">
+    <Style src="project://database/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uss?fileID=7433441132597879392&amp;guid=0c061ff59c04373489742356252f97ea&amp;type=3#PackageWizard" />
+    <ui:Foldout text="Package Name" name="custom-dependency-group" class="box-group foldout-group" style="flex-direction: column;">
+        <ui:VisualElement style="flex-direction: row; padding-left: 2px; padding-right: 2px; padding-top: 2px; padding-bottom: 2px;">
+            <ui:TextField picking-mode="Ignore" label="DisplayName" name="display-name" style="flex-direction: column; flex-shrink: 1; width: 33%;" />
+            <ui:TextField picking-mode="Ignore" label="Domain" name="domain-name" style="flex-direction: column; flex-shrink: 1; flex-grow: 1; width: 33%;" />
+            <ui:TextField picking-mode="Ignore" label="Version" name="version" style="flex-direction: column; flex-shrink: 1; width: 33%;" />
+        </ui:VisualElement>
+        <ui:VisualElement style="padding-left: 2px; padding-right: 2px; padding-top: 2px; padding-bottom: 2px;">
+            <ui:TextField picking-mode="Ignore" label="Source" name="source" />
+        </ui:VisualElement>
+    </ui:Foldout>
+</ui:UXML>

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyData.uxml.meta
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyData.uxml.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cc886056d5cc45de907a659aef3ac19a
+timeCreated: 1670430388

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyDataCustomEditor.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyDataCustomEditor.cs
@@ -1,0 +1,40 @@
+using Scripts.Core;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
+{
+    [CustomPropertyDrawer(typeof(PackageData.DependencyData))]
+    public class DependencyDataCustomEditor : PropertyDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            // Create a new VisualElement to be the root of our inspector UI
+            VisualElement myInspector = new VisualElement();
+            // Load and clone a visual tree from UXML
+            VisualTreeAsset visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(R.UI.DependencyData.UXMLPath);
+            visualTree.CloneTree(myInspector);
+
+            var groupBox = myInspector.Q<Foldout>(R.UI.DependencyData.GroupBoxName);
+            
+            var foldoutLabel = groupBox
+                .Q<Label>(className: Foldout.textUssClassName);
+            var displayNameProperty = property.FindPropertyRelative(nameof(PackageData.DependencyData.DisplayName));
+            foldoutLabel.BindProperty(displayNameProperty);
+
+            
+            var displayNameTextField = groupBox.Q<TextField>(R.UI.DependencyData.DisplayNameField);
+            displayNameTextField.BindProperty(displayNameProperty);
+            var domainNameTextField = groupBox.Q<TextField>(R.UI.DependencyData.DomainNameField);
+            domainNameTextField.BindProperty(property.FindPropertyRelative(nameof(PackageData.DependencyData.Domain)));
+            var versionTextField = groupBox.Q<TextField>(R.UI.DependencyData.VersionField);
+            versionTextField.BindProperty(property.FindPropertyRelative(nameof(PackageData.DependencyData.Version)));
+            var sourceTextField = groupBox.Q<TextField>(R.UI.DependencyData.SourceField);
+            sourceTextField.BindProperty(property.FindPropertyRelative(nameof(PackageData.DependencyData.Source)));
+
+            // Return the finished inspector UI
+            return myInspector;
+        }
+    }
+}

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyDataCustomEditor.cs.meta
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyDataCustomEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 12a94f1a419e460caf0de03b4fef823e
+timeCreated: 1670430260

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uss
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uss
@@ -28,6 +28,27 @@ GroupBox .unity-toggle {
     flex-shrink: 1;
 }
 
+/*Foldout Group Styles*/
+/*======================================================*/
+Foldout.foldout-group {
+    border-width: 1px;
+    border-radius: 2px;
+    border-color: rgb(45,45,45);
+    background-color: rgb(65,65,65);
+    margin: 5px;
+    padding: 0;
+}
+Foldout.foldout-group > Toggle.unity-foldout__toggle{
+    background-color: rgb(85,85,85);
+    margin: 0;
+    padding: 2px;
+    max-width: none;
+    font-size: 14;
+}
+Foldout.foldout-group > #unity-content{
+    padding: 5px;
+}
+
 /*Group Styling to support Wrapping Rows*/
 /*======================================================*/
 .dependency-group .container {

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uxml
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uxml
@@ -1,31 +1,33 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
     <Style src="project://database/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uss?fileID=7433441132597879392&amp;guid=0c061ff59c04373489742356252f97ea&amp;type=3#PackageWizard" />
-    <ui:Label text="Package Details" name="Title" class="section-title" style="font-size: 20px; -unity-text-align: upper-left; margin-left: 5px; margin-right: 5px; margin-top: 5px; margin-bottom: 12px;" />
-    <ui:TextField picking-mode="Ignore" label="Experience Name" value="filler text" name="ExperienceName" style="border-left-width: 6px; border-right-width: 6px; border-top-width: 6px; border-bottom-width: 6px;" />
-    <ui:Toggle label="Does it Score?" name="IfScore" style="margin-left: 6px; margin-right: 6px; margin-top: 6px; margin-bottom: 6px;" />
-    <ui:VisualElement name="PlatformOptionsPlaceholder" />
-    <uie:EnumField label="Render Pipeline" value="Center" name="RenderPipeline" style="margin-left: 6px; margin-right: 6px; margin-top: 6px; margin-bottom: 6px;" />
-    <ui:Toggle label="Does it require Editor Scripts?" name="IfRequireEditorScripts" style="margin-left: 6px; margin-right: 6px; margin-top: 6px; margin-bottom: 6px;" />
-    <ui:DropdownField label="Unity Editor Version" index="-1" choices="System.Collections.Generic.List`1[System.String]" name="UnityEditorVersion" style="margin-bottom: 6px; margin-left: 6px; margin-right: 6px; margin-top: 6px;" />
-    <ui:GroupBox text="Experience Tags" name="experience-tags" class="box-group" style="min-height: 100px; max-height: 250px;">
-        <ui:ScrollView name="FDTags" horizontal-scroller-visibility="Hidden" style="flex-wrap: wrap; flex-direction: row;" />
-    </ui:GroupBox>
-    <ui:Label text="Author Details" display-tooltip-when-elided="true" class="section-title" style="font-size: 17px; -unity-text-align: upper-left; border-left-width: 4px; border-right-width: 4px; border-top-width: 4px; border-bottom-width: 4px;" />
-    <ui:TextField picking-mode="Ignore" label="Author Name" name="IfAuthor" style="border-left-width: 5px; border-right-width: 5px; border-top-width: 5px; border-bottom-width: 5px;" />
-    <ui:TextField picking-mode="Ignore" label="Description" text="Tell us what your project is all about!" multiline="true" name="IfDescription" style="height: 60px; border-bottom-width: 6px; border-left-width: 6px; border-right-width: 6px; border-top-width: 6px;" />
-    <ui:GroupBox text="Optional Dependencies" name="optional-dependencies" class="box-group dependency-group" style="max-height: 250px; min-height: 100px;">
-        <ui:ScrollView name="ScrollDependencies" />
-    </ui:GroupBox>
-    <ui:Foldout text="Select" name="SCDependencies" value="false" style="display: none;" />
-    <ui:TextField picking-mode="Ignore" label="Any Extra Dependencies?" name="IFExtraDependencies" tooltip="Comma separated Please" style="display: none;" />
-    <ui:VisualElement name="StateButtons" style="flex-direction: row; align-items: center; justify-content: center; display: flex; border-left-width: 6px; border-right-width: 6px; border-top-width: 6px; border-bottom-width: 6px; height: 100px;">
-        <ui:Button text="Generate Package" display-tooltip-when-elided="true" name="GeneratePackage" style="flex-grow: 1; height: 30px;" />
-        <ui:Button text="Load Package" display-tooltip-when-elided="true" name="LoadPackage" style="flex-grow: 1; height: 30px; display: none;" />
-        <ui:Button text="Clear Data" display-tooltip-when-elided="true" name="ClearButton" style="height: 30px; flex-grow: 1;" />
-        <ui:Button text="Refresh Database" display-tooltip-when-elided="true" name="RefreshButton" style="height: 30px; flex-grow: 1;" />
-    </ui:VisualElement>
-    <ui:ProgressBar title="Hang Tight!" name="FileProgressBar" style="margin-left: 5px; margin-right: 5px; margin-top: 5px; margin-bottom: 5px; display: flex;" />
-    <ui:VisualElement name="WarningContainer" style="height: 57px; flex-direction: row; background-color: rgb(47, 47, 47); border-left-width: 5px; border-right-width: 5px; border-top-width: 5px; border-bottom-width: 5px; padding-bottom: 39px;">
-        <ui:Label text="This is a warning " display-tooltip-when-elided="true" name="WarningLabel" style="flex-grow: 1; -unity-text-align: middle-center; border-left-width: 7px; border-right-width: 7px; border-top-width: 7px; border-bottom-width: 7px; font-size: 17px; color: rgb(255, 255, 255); -unity-font-style: normal; padding-left: 12px; padding-right: 12px; padding-top: 12px; padding-bottom: 12px;" />
-    </ui:VisualElement>
+    <ui:ScrollView>
+        <ui:Label text="Package Details" name="Title" class="section-title" style="font-size: 20px; -unity-text-align: upper-left; margin-left: 5px; margin-right: 5px; margin-top: 5px; margin-bottom: 12px;" />
+        <ui:TextField picking-mode="Ignore" label="Experience Name" value="filler text" name="ExperienceName" style="border-left-width: 6px; border-right-width: 6px; border-top-width: 6px; border-bottom-width: 6px;" />
+        <ui:Toggle label="Does it Score?" name="IfScore" style="margin-left: 6px; margin-right: 6px; margin-top: 6px; margin-bottom: 6px;" />
+        <ui:VisualElement name="PlatformOptionsPlaceholder" />
+        <uie:EnumField label="Render Pipeline" value="Center" name="RenderPipeline" style="margin-left: 6px; margin-right: 6px; margin-top: 6px; margin-bottom: 6px;" />
+        <ui:Toggle label="Does it require Editor Scripts?" name="IfRequireEditorScripts" style="margin-left: 6px; margin-right: 6px; margin-top: 6px; margin-bottom: 6px;" />
+        <ui:DropdownField label="Unity Editor Version" index="-1" choices="System.Collections.Generic.List`1[System.String]" name="UnityEditorVersion" style="margin-bottom: 6px; margin-left: 6px; margin-right: 6px; margin-top: 6px;" />
+        <ui:GroupBox text="Experience Tags" name="experience-tags" class="box-group" style="min-height: 100px; max-height: 250px;">
+            <ui:ScrollView name="FDTags" horizontal-scroller-visibility="Hidden" style="flex-wrap: wrap; flex-direction: row;" />
+        </ui:GroupBox>
+        <ui:Label text="Author Details" display-tooltip-when-elided="true" class="section-title" style="font-size: 17px; -unity-text-align: upper-left; border-left-width: 4px; border-right-width: 4px; border-top-width: 4px; border-bottom-width: 4px;" />
+        <ui:TextField picking-mode="Ignore" label="Author Name" name="IfAuthor" style="border-left-width: 5px; border-right-width: 5px; border-top-width: 5px; border-bottom-width: 5px;" />
+        <ui:TextField picking-mode="Ignore" label="Description" text="Tell us what your project is all about!" multiline="true" name="IfDescription" style="height: 60px; border-bottom-width: 6px; border-left-width: 6px; border-right-width: 6px; border-top-width: 6px;" />
+        <ui:GroupBox text="Optional Dependencies" name="optional-dependencies" class="box-group dependency-group" style="max-height: 250px; min-height: 100px;">
+            <ui:ScrollView name="ScrollDependencies" />
+        </ui:GroupBox>
+        <ui:Foldout text="Select" name="SCDependencies" value="false" style="display: none;" />
+        <ui:TextField picking-mode="Ignore" label="Any Extra Dependencies?" name="IFExtraDependencies" tooltip="Comma separated Please" style="display: none;" />
+        <ui:VisualElement name="StateButtons" style="flex-direction: row; align-items: center; justify-content: center; display: flex; border-left-width: 6px; border-right-width: 6px; border-top-width: 6px; border-bottom-width: 6px; height: 100px;">
+            <ui:Button text="Generate Package" display-tooltip-when-elided="true" name="GeneratePackage" style="flex-grow: 1; height: 30px;" />
+            <ui:Button text="Load Package" display-tooltip-when-elided="true" name="LoadPackage" style="flex-grow: 1; height: 30px; display: none;" />
+            <ui:Button text="Clear Data" display-tooltip-when-elided="true" name="ClearButton" style="height: 30px; flex-grow: 1;" />
+            <ui:Button text="Refresh Database" display-tooltip-when-elided="true" name="RefreshButton" style="height: 30px; flex-grow: 1;" />
+        </ui:VisualElement>
+        <ui:ProgressBar title="Hang Tight!" name="FileProgressBar" style="margin-left: 5px; margin-right: 5px; margin-top: 5px; margin-bottom: 5px; display: flex;" />
+        <ui:VisualElement name="WarningContainer" style="height: 57px; flex-direction: row; background-color: rgb(47, 47, 47); border-left-width: 5px; border-right-width: 5px; border-top-width: 5px; border-bottom-width: 5px; padding-bottom: 39px;">
+            <ui:Label text="This is a warning " display-tooltip-when-elided="true" name="WarningLabel" style="flex-grow: 1; -unity-text-align: middle-center; border-left-width: 7px; border-right-width: 7px; border-top-width: 7px; border-bottom-width: 7px; font-size: 17px; color: rgb(255, 255, 255); -unity-font-style: normal; padding-left: 12px; padding-right: 12px; padding-top: 12px; padding-bottom: 12px;" />
+        </ui:VisualElement>
+    </ui:ScrollView>
 </ui:UXML>

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uxml
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/PackageWizard.uxml
@@ -17,6 +17,9 @@
         <ui:GroupBox text="Optional Dependencies" name="optional-dependencies" class="box-group dependency-group" style="max-height: 250px; min-height: 100px;">
             <ui:ScrollView name="ScrollDependencies" />
         </ui:GroupBox>
+        <ui:GroupBox text="Custom Dependencies" class="box-group dependency-group">
+            <ui:ListView focusable="true" name="custom-dependencies" show-add-remove-footer="true" reorderable="true" virtualization-method="DynamicHeight" show-alternating-row-backgrounds="ContentOnly" style="flex-grow: 1;" />
+        </ui:GroupBox>
         <ui:Foldout text="Select" name="SCDependencies" value="false" style="display: none;" />
         <ui:TextField picking-mode="Ignore" label="Any Extra Dependencies?" name="IFExtraDependencies" tooltip="Comma separated Please" style="display: none;" />
         <ui:VisualElement name="StateButtons" style="flex-direction: row; align-items: center; justify-content: center; display: flex; border-left-width: 6px; border-right-width: 6px; border-top-width: 6px; border-bottom-width: 6px; height: 100px;">

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/R.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/R.cs
@@ -42,6 +42,18 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
 
         
             public const string Title = "PackageWizard";
+            
+            public class DependencyData
+            {
+                public const string UXMLPath =
+                    "Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/DependencyData.uxml";
+                public const string GroupBoxName = "custom-dependency-group";
+
+                public const string DisplayNameField = "display-name";
+                public const string DomainNameField = "domain-name";
+                public const string VersionField = "version";
+                public const string SourceField = "source";
+            }
         }
         
 

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/R.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/EditorWindow/R.cs
@@ -73,71 +73,104 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.feature.2d",
+                        DisplayName = "2D Features",
+                        Domain = "com.unity.feature.2d",
                         Version = "1.0.0"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.editorcoroutines",
+                        DisplayName = "Editor Coroutines",
+                        Domain = "com.unity.editorcoroutines",
                         Version = "1.0.0"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.postprocessing",
+                        DisplayName = "Post Processing",
+                        Domain = "com.unity.postprocessing",
                         Version = "3.2.2"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.probuilder",
+                        DisplayName = "Pro Builder",
+                        Domain = "com.unity.probuilder",
                         Version = "5.0.6"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.textmeshpro",
+                        DisplayName = "TextMeshPro",
+                        Domain = "com.unity.textmeshpro",
                         Version = "3.0.6"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.timeline",
+                        DisplayName = "Timeline",
+                        Domain = "com.unity.timeline",
                         Version = "1.6.4"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.visualeffectgraph",
+                        DisplayName = "Visual Effects Graph",
+                        Domain = "com.unity.visualeffectgraph",
                         Version = "12.1.7"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.visualscripting",
+                        DisplayName = "Visual Scripting",
+                        Domain = "com.unity.visualscripting",
                         Version = "1.7.8"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.nuget.newtonsoft-json",
+                        DisplayName = "Newtonsoft Json",
+                        Domain = "com.unity.nuget.newtonsoft-json",
                         Version = "3.0.2"
+                    },
+                    new PackageData.DependencyData
+                    {
+                        DisplayName = "UIToolkit Attributes",
+                        Domain = "com.miniproject.uitoolkitattributes",
+                        Version = "0.0.1",
+                        Source = "https://github.com/AlexBedardReidU3D/UIToolkitAttributes.git"
                     }
                 },
                 [PackageData.Dependency.URP] = new[]
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.render-pipelines.universal",
+                        DisplayName = "Unity URP",
+                        Domain = "com.unity.render-pipelines.universal",
                         Version = "12.1.7"
+                    },
+                    new PackageData.DependencyData
+                    {
+                        DisplayName = "MiniProject URP",
+                        Domain = "com.miniproject.urp",
+                        Version = "0.0.1",
+                        Source = "file:../../../../../Packages/com.miniproject.urp"
                     }
                 },
                 [PackageData.Dependency.HDRP] = new[]
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.render-pipelines.high-definition",
+                        DisplayName = "Unity HDRP",
+                        Domain = "com.unity.render-pipelines.high-definition",
                         Version = "12.1.7"
+                    },
+                    new PackageData.DependencyData
+                    {
+                        DisplayName = "MiniProject HDRP",
+                        Domain = "com.miniproject.hdrp",
+                        Version = "0.0.1",
+                        Source = "file:../../../../../Packages/com.miniproject.hdrp"
                     }
                 },
                 [PackageData.Dependency.Android] = new[]
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.mobile.android-logcat",
+                        DisplayName = "Logcat",
+                        Domain = "com.unity.mobile.android-logcat",
                         Version = "1.3.2"
                     }
                 },
@@ -145,7 +178,8 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.cinemachine",
+                        DisplayName = "Cinemachine",
+                        Domain = "com.unity.cinemachine",
                         Version = "2.8.9"
                     }
                 },
@@ -153,7 +187,8 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.shadergraph",
+                        DisplayName = "Shader Graph",
+                        Domain = "com.unity.shadergraph",
                         Version = "12.1.7"
                     }
                 },
@@ -161,7 +196,8 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.xr.openxr",
+                        DisplayName = "Open XR",
+                        Domain = "com.unity.xr.openxr",
                         Version = "1.5.3"
                     }
                 },
@@ -169,7 +205,8 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.xr.openxr",
+                        DisplayName = "Open XR",
+                        Domain = "com.unity.xr.openxr",
                         Version = "1.5.3"
                     }
                 },
@@ -177,12 +214,14 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.mathematics",
+                        DisplayName = "Mathematics",
+                        Domain = "com.unity.mathematics",
                         Version = "1.2.6"
                     },
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.ml-agents",
+                        DisplayName = "ML Agents",
+                        Domain = "com.unity.ml-agents",
                         Version = "2.0.1"
                     }
                 },
@@ -190,7 +229,8 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.inputsystem",
+                        DisplayName = "Input System",
+                        Domain = "com.unity.inputsystem",
                         Version = "1.4.4"
                     }
                 },
@@ -198,7 +238,8 @@ namespace MiniProject.Core.Editor.PackageWizard.EditorWindow
                 {
                     new PackageData.DependencyData
                     {
-                        Name = "com.unity.terrain-tools",
+                        DisplayName = "Terrain Tools",
+                        Domain = "com.unity.terrain-tools",
                         Version = "4.0.3"
                     }
                 },

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/File Writers/ManifestWriter.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/File Writers/ManifestWriter.cs
@@ -38,7 +38,7 @@ namespace MiniProject.Core.Editor.PackageWizard
         public void UpdateManifestFiles(in string packageName, 
             PackageData.UnityVersion[] supportedUnityVersions, 
             PackageData.Platform[] supportedPlatforms,
-            PackageData.Dependency[] packageDependencies,
+            PackageData.DependencyData[] packageDependencies,
             PackageData.DependencyData[] customDependencies)
         {
             bool DirectoryContainsItem(in DirectoryInfo directoryInfo, in string[] searchFor)
@@ -222,22 +222,17 @@ namespace MiniProject.Core.Editor.PackageWizard
         /// <param name="customDependencies"></param>
         /// <returns></returns>
         private static List<KeyValuePair<string, string>> GetAsManifestDependencies(
-            in IEnumerable<PackageData.Dependency> dependencies, 
+            in IEnumerable<PackageData.DependencyData> dependencies, 
             in IEnumerable<PackageData.DependencyData> customDependencies)
         {
             var packageDependencies = new List<KeyValuePair<string, string>>();
 
-            foreach (var d in dependencies)
+            foreach (var dependencyData in dependencies)
             {
-                var temp = R.Dependencies.DependencyDatas[d];
-
-                foreach (var dependencyData in temp)
-                {
-                    if(string.IsNullOrWhiteSpace(dependencyData.Source))
-                        continue;
+                if(string.IsNullOrWhiteSpace(dependencyData.Source))
+                    continue;
                     
-                    packageDependencies.Add(new KeyValuePair<string, string>(dependencyData.Name, dependencyData.Source));
-                }
+                packageDependencies.Add(new KeyValuePair<string, string>(dependencyData.Domain, dependencyData.Source));
             }
 
             foreach (var dependencyData in customDependencies)
@@ -245,7 +240,7 @@ namespace MiniProject.Core.Editor.PackageWizard
                 if(string.IsNullOrWhiteSpace(dependencyData.Source))
                     continue;
                     
-                packageDependencies.Add(new KeyValuePair<string, string>(dependencyData.Name, dependencyData.Source));
+                packageDependencies.Add(new KeyValuePair<string, string>(dependencyData.Domain, dependencyData.Source));
             }
 
             return packageDependencies;

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/File Writers/PackageJsonWriter.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/File Writers/PackageJsonWriter.cs
@@ -60,7 +60,7 @@ namespace MiniProject.Core.Editor.PackageWizard
         /// <param name="customDependencies"></param>
         /// <returns></returns>
         private static JObject GetPackageDependenciesAsJObject(
-            in IEnumerable<PackageData.Dependency> dependencies,
+            in IEnumerable<PackageData.DependencyData> dependencies,
             in IEnumerable<PackageData.DependencyData> customDependencies)
         {
             var packageDependencies = new JObject();
@@ -68,19 +68,14 @@ namespace MiniProject.Core.Editor.PackageWizard
             if (dependencies == null || dependencies.Any() == false)
                 return packageDependencies;
 
-            foreach (var d in dependencies)
+            foreach (var dependencyData in dependencies)
             {
-                var temp = R.Dependencies.DependencyDatas[d];
-
-                foreach (var dependencyData in temp)
-                {
-                    packageDependencies.Add(dependencyData.Name, dependencyData.Version);
-                }
+                packageDependencies.Add(dependencyData.Domain, dependencyData.Version);
             }
 
             foreach (var dependencyData in customDependencies)
             {
-                packageDependencies.Add(dependencyData.Name, dependencyData.Version);
+                packageDependencies.Add(dependencyData.Domain, dependencyData.Version);
             }
 
             return packageDependencies;

--- a/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/PackageGenerator.cs
+++ b/Packages/com.miniproject.core/Editor/Scripts/PackageWizard/PackageGenerator.cs
@@ -162,7 +162,7 @@ namespace MiniProject.Core.Editor.PackageWizard
         private void UpdateManifests(in string packageName, 
             in PackageData.UnityVersion[] supportedUnityVersions,
             in PackageData.Platform[] supportedPlatforms,
-            in PackageData.Dependency[] dependencies,
+            in PackageData.DependencyData[] dependencies,
             in PackageData.DependencyData[] customDependencies)
         {
             OnProgressChanged?.Invoke(this, new ProgressEventArgs(R.Progress.Manifest, .7f));

--- a/Packages/com.miniproject.core/Runtime/Scripts/Core/PackageData.cs
+++ b/Packages/com.miniproject.core/Runtime/Scripts/Core/PackageData.cs
@@ -42,6 +42,7 @@ namespace Scripts.Core
 
         public enum RenderingPipeline
         {
+            BuiltIn,
             URP,
             HDRP
         }
@@ -70,7 +71,8 @@ namespace Scripts.Core
 
         public struct DependencyData
         {
-            public string Name { get; set; }
+            public string DisplayName { get; set; }
+            public string Domain { get; set; }
             public string Version { get; set; }
             //for com.unity packages, no need to include the source, the version should
             public string Source { get; set; }
@@ -90,7 +92,7 @@ namespace Scripts.Core
         /// </summary>
         public List<RenderingPipeline> RenderingPipelines{ get; set; }
 
-        public List<Dependency> Dependencies { get; set; }
+        public List<DependencyData> Dependencies { get; set; }
         public List<DependencyData> CustomDependencies { get; set; }
 
         public string DisplayName { get; set; }

--- a/Packages/com.miniproject.core/Runtime/Scripts/Core/PackageData.cs
+++ b/Packages/com.miniproject.core/Runtime/Scripts/Core/PackageData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
@@ -69,13 +70,14 @@ namespace Scripts.Core
             public string Url { get; set; }
         }
 
+        [Serializable]
         public struct DependencyData
         {
-            public string DisplayName { get; set; }
-            public string Domain { get; set; }
-            public string Version { get; set; }
+            public string DisplayName;
+            public string Domain;
+            public string Version;
             //for com.unity packages, no need to include the source, the version should
-            public string Source { get; set; }
+            public string Source;
         }
 
         /// <summary>


### PR DESCRIPTION
**Description**

General improvements to the Package Wizard UI & stability improvements. Now when pressing the Generate button, an exception is no longer thrown.

- Added Built-in as a Pipeline option, set as default selected
- Set Default platform target to be currently selected platform in editor
- Moved PackageWizard UXML contents into a Root `ScrollRect` to resolve overflow issues
- Changed Package Dependency `Toggle` label to use a `DisplayName` instead of `Domain`
  - `Toggle` tooltip will display the `Domain` now
- Dependencies will now save to `PackageData` when pressing generate
- Added Custom Dependencies functionality to Editor Window
  - Created custom `Foldout Editor` for `DependencyData` to be used in `ListView`
  - Set `DependencyData` fields as serializable to be edited
- Custom Dependencies will now save to `PackageData` when pressing generate
- Added Miniproject packages to Dependency Lists:
  - `com.miniproject.uitoolkitattributes` :arrow_right: Common 
  - `com.miniproject.urp` :arrow_right: URP
  - `com.miniproject.hdrp` :arrow_right: HDRP

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

**Screenshot if applicable**
![Screenshot 2022-12-07 102012](https://user-images.githubusercontent.com/114178283/206264227-47dd0870-b53b-4a16-8adf-40ff362137dd.png)



**Checklist**
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Develop has been merged into this branch
- [x] Project builds and runs in Unity Editor